### PR TITLE
Update Paternity Leave logic in visual planner and accessible planner

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -2,7 +2,7 @@ const delve = require('dlv')
 const { getWeeksArray, parseWeeksFromData } = require('./utils')
 const Day = require('../common/lib/day')
 const { parseEligibilityFromData } = require('./lib/eligibility')
-const { getBlockLength, getRemainingLeaveAllowance, getRemainingPayAllowance, parseLeaveBlocks, parseSplLeaveBlocks } = require('./lib/blocks')
+const { getBlockLength, getPaternalBlockLength, getRemainingLeaveAllowance, getRemainingPayAllowance, parseLeaveBlocks, parseSplLeaveBlocks } = require('./lib/blocks')
 const _ = require('lodash')
 
 // Existing filters can be imported from env using env.getFilter(name)
@@ -138,6 +138,10 @@ module.exports = function (env) {
     return getBlockLength(block)
   }
 
+  function paternalBlockLength (block) {
+    return getPaternalBlockLength(block)
+  }
+
   function remainingLeaveAllowance (leaveBlocksDataObject) {
     const leaveBlocks = parseLeaveBlocks(leaveBlocksDataObject)
     return getRemainingLeaveAllowance(leaveBlocks)
@@ -189,6 +193,7 @@ module.exports = function (env) {
     blocksToDates,
     htmlAttributesFromObject,
     blockLength,
+    paternalBlockLength,
     remainingLeaveAllowance,
     remainingPayAllowance,
     hasTakenSpl,

--- a/app/lib/blocks.js
+++ b/app/lib/blocks.js
@@ -151,7 +151,6 @@ function calculatePaternityLeaveWeeks (leave) {
 }
 
 function getBlocks (data) {
-  console.log(data);
   const dataClone = _.cloneDeep(data)
   const leaveBlocksDataObject = dataClone['leave-blocks']
   if (leaveBlocksDataObject) {
@@ -274,6 +273,16 @@ function getBlockLength (block) {
   return parseInt(block.end) - parseInt(block.start) + 1
 }
 
+function getPaternalBlockLength (block) {
+  if (!block || block.length === 0) {
+    return 0
+  } else if (block.length === 2) {
+    return 2
+  } else if (block.length === 1) {
+    return parseInt(block[0].end) - parseInt(block[0].start) + 1
+  }
+}
+
 function isBlockDataObject (obj) {
   return _.isObject(obj) &&
     obj.leave !== undefined &&
@@ -358,5 +367,6 @@ module.exports = {
   getRemainingLeaveAllowance,
   getRemainingPayAllowance,
   getBlockLength,
+  getPaternalBlockLength,
   parseLeaveBlocksIntoLeaveAndPay
 }

--- a/app/lib/blocks.js
+++ b/app/lib/blocks.js
@@ -14,7 +14,7 @@ function getLeaveBlocks (weeks) {
 
 function getParentLeaveBlocks (weeks, parent) {
   const blocks = {
-    initial: null,
+    initial: [],
     spl: []
   }
 
@@ -28,9 +28,9 @@ function getParentLeaveBlocks (weeks, parent) {
 
   function store (block) {
     if (block && ['maternity', 'paternity', 'adoption'].includes(block.leave)) {
-      blocks.initial = block
+      blocks.initial.push(block);
     } else {
-      blocks.spl.push(block)
+      blocks.spl.push(block);
     }
   }
 
@@ -151,6 +151,7 @@ function calculatePaternityLeaveWeeks (leave) {
 }
 
 function getBlocks (data) {
+  console.log(data);
   const dataClone = _.cloneDeep(data)
   const leaveBlocksDataObject = dataClone['leave-blocks']
   if (leaveBlocksDataObject) {

--- a/app/lib/leaveTracker.js
+++ b/app/lib/leaveTracker.js
@@ -5,6 +5,7 @@ class LeaveTracker {
     this.initialBlockStarted = false
     this.initialBlockEnded = false
     this.initialBlockLength = 0
+    this.totalLeaveWeeks = 0
   }
 
   next (isLeave, weekNumber) {
@@ -16,6 +17,9 @@ class LeaveTracker {
     this.initialBlockEnded = this.initialBlockEnded || (this.initialBlockStarted && !isLeave)
     if (this.initialBlockStarted && !this.initialBlockEnded) {
       this.initialBlockLength++
+    }
+    if (isLeave) {
+      this.totalLeaveWeeks++
     }
   }
 

--- a/app/lib/weeks.js
+++ b/app/lib/weeks.js
@@ -53,8 +53,8 @@ class Weeks {
       if (!week.secondary.disabled) {
         secondaryLeaveTracker.next(weekLeaveAndPay.secondary.leave, i)
         if (weekLeaveAndPay.secondary.leave) {
-          const maxCellsDisplayedAsPaternity = this.eligibility.secondary.spl || this.eligibility.secondary.shpp ? 2 : 8
-          const usePaternityLeave = i < 8 && !secondaryLeaveTracker.initialBlockEnded && secondaryLeaveTracker.initialBlockLength <= maxCellsDisplayedAsPaternity
+          const maxCellsDisplayedAsPaternity = this.eligibility.secondary.spl || this.eligibility.secondary.shpp ? 2 : 52
+          const usePaternityLeave = i < 52 && !secondaryLeaveTracker.initialBlockEnded && secondaryLeaveTracker.initialBlockLength <= maxCellsDisplayedAsPaternity
           dset(week.secondary, 'leave.text', usePaternityLeave ? 'paternity' : 'shared')
           if (weekLeaveAndPay.secondary.pay) {
             dset(week.secondary, 'pay.text', this.payRates.secondary.statutory)
@@ -89,7 +89,7 @@ class Weeks {
     if (this.eligibility.secondary.spl) {
       return true
     } else if (this.eligibility.secondary.statutoryLeave) {
-      return week.secondary.leave.text === 'paternity' && week.number < 8
+      return week.secondary.leave.text === 'paternity' && week.number < 52
     } else {
       return false
     }
@@ -116,7 +116,7 @@ class Weeks {
     } else if (!this.eligibility.secondary.statutoryPay) {
       return false
     } else if (!this.eligibility.secondary.spl) {
-      return week.number < 8
+      return week.number < 52
     } else {
       return week.secondary.leave.text === 'paternity'
     }

--- a/app/lib/weeks.js
+++ b/app/lib/weeks.js
@@ -56,8 +56,12 @@ class Weeks {
           const maxCellsDisplayedAsPaternity = 2
           const usePaternityLeave = secondaryLeaveTracker.totalLeaveWeeks <= maxCellsDisplayedAsPaternity
 
+          const latestPrimaryWeekLeave = this._getLatestPrimaryWeekLeave();
+
           // determine whether to display paternity or shared pay label
-          if (usePaternityLeave) {
+          // the label should say "Paternity" if there are enough weeks left e.g. totalLeaveWeeks <= 2
+          // and the selected week is within the range of the mother's leave
+          if (usePaternityLeave && weekNumber <= latestPrimaryWeekLeave) {
             dset(week.secondary, 'leave.text', 'paternity')
           } else {
             dset(week.secondary, 'leave.text', 'shared')
@@ -223,6 +227,11 @@ class Weeks {
   _formatPay (pay) {
     const payAsFloat = parseFloat(pay)
     return isNaN(payAsFloat) ? pay : ('£' + (+payAsFloat.toFixed(2)).toLocaleString('en-US'))
+  }
+
+  _getLatestPrimaryWeekLeave() {
+    const primaryLeaveWeeks = this.primary.leaveWeeks;
+    return primaryLeaveWeeks.length > 0 ? Math.max(...primaryLeaveWeeks) : 0;
   }
 }
 

--- a/app/lib/weeks.js
+++ b/app/lib/weeks.js
@@ -23,16 +23,16 @@ class Weeks {
     const secondaryLeaveTracker = new LeaveTracker()
     let hasCurtailedPrimaryPay = false
     let primarySplHasStarted = false
-    for (let i = this.minimumWeek; i <= 52; i++) {
-      const week = this._getBaseWeek(i)
-      const weekLeaveAndPay = this._getWeekLeaveAndPay(i)
+    for (let weekNumber = this.minimumWeek; weekNumber <= 52; weekNumber++) {
+      const week = this._getBaseWeek(weekNumber)
+      const weekLeaveAndPay = this._getWeekLeaveAndPay(weekNumber)
 
-      primaryLeaveTracker.next(weekLeaveAndPay.primary.leave, i)
+      primaryLeaveTracker.next(weekLeaveAndPay.primary.leave, weekNumber)
       if (weekLeaveAndPay.primary.leave) {
         if (!primarySplHasStarted) {
           const startSplBecauseOfBreak = primaryLeaveTracker.initialBlockEnded
           const startSplBecauseOfPayAfterCurtailment = hasCurtailedPrimaryPay && weekLeaveAndPay.primary.pay
-          const startSplBecauseOfUserSelect = this.primary.firstSplWeek <= i
+          const startSplBecauseOfUserSelect = this.primary.firstSplWeek <= weekNumber
           primarySplHasStarted = startSplBecauseOfBreak || startSplBecauseOfPayAfterCurtailment || startSplBecauseOfUserSelect
         }
         dset(week.primary, 'leave.text', !primarySplHasStarted ? this.primaryLeaveType : 'shared')
@@ -51,16 +51,28 @@ class Weeks {
       }
 
       if (!week.secondary.disabled) {
-        secondaryLeaveTracker.next(weekLeaveAndPay.secondary.leave, i)
+        secondaryLeaveTracker.next(weekLeaveAndPay.secondary.leave, weekNumber)
         if (weekLeaveAndPay.secondary.leave) {
-          const maxCellsDisplayedAsPaternity = this.eligibility.secondary.spl || this.eligibility.secondary.shpp ? 2 : 52
-          const usePaternityLeave = i < 52 && !secondaryLeaveTracker.initialBlockEnded && secondaryLeaveTracker.initialBlockLength <= maxCellsDisplayedAsPaternity
-          dset(week.secondary, 'leave.text', usePaternityLeave ? 'paternity' : 'shared')
+          const maxCellsDisplayedAsPaternity = 2
+          const usePaternityLeave = secondaryLeaveTracker.totalLeaveWeeks <= maxCellsDisplayedAsPaternity
+
+          // determine whether to display paternity or shared pay label
+          if (usePaternityLeave) {
+            dset(week.secondary, 'leave.text', 'paternity')
+          } else {
+            dset(week.secondary, 'leave.text', 'shared')
+          }
+
+          // determine whether to display pay label
           if (weekLeaveAndPay.secondary.pay) {
             dset(week.secondary, 'pay.text', this.payRates.secondary.statutory)
           }
+
+          // determine whether to display pay checkbox
           dset(week.secondary, 'pay.eligible', this._weekEligibleForSecondaryPay(week))
         }
+
+        // determine whether to display leave checkbox
         dset(week.secondary, 'leave.eligible', this._weekEligibleForSecondaryLeave(week))
       }
 

--- a/app/lib/weeks.js
+++ b/app/lib/weeks.js
@@ -56,12 +56,12 @@ class Weeks {
           const maxCellsDisplayedAsPaternity = 2
           const usePaternityLeave = secondaryLeaveTracker.totalLeaveWeeks <= maxCellsDisplayedAsPaternity
 
-          const latestPrimaryWeekLeave = this._getLatestPrimaryWeekLeave();
+          const latestPrimaryWeekLeave = this._getLatestPrimaryMaternityWeekLeave();
 
           // determine whether to display paternity or shared pay label
           // the label should say "Paternity" if there are enough weeks left e.g. totalLeaveWeeks <= 2
           // and the selected week is within the range of the mother's leave
-          if (usePaternityLeave && weekNumber <= latestPrimaryWeekLeave) {
+          if (usePaternityLeave && weekNumber <= latestPrimaryWeekLeave && week.primary.leave.text === 'maternity') {
             dset(week.secondary, 'leave.text', 'paternity')
           } else {
             dset(week.secondary, 'leave.text', 'shared')
@@ -229,7 +229,7 @@ class Weeks {
     return isNaN(payAsFloat) ? pay : ('£' + (+payAsFloat.toFixed(2)).toLocaleString('en-US'))
   }
 
-  _getLatestPrimaryWeekLeave() {
+  _getLatestPrimaryMaternityWeekLeave() {
     const primaryLeaveWeeks = this.primary.leaveWeeks;
     return primaryLeaveWeeks.length > 0 ? Math.max(...primaryLeaveWeeks) : 0;
   }

--- a/app/paths.js
+++ b/app/paths.js
@@ -201,11 +201,6 @@ class Paths {
             workFlowPage: true,
             workflowParentPath: '/planner/paternity-leave'
           },
-          end: {
-            url: '/planner/paternity-leave/end',
-            workFlowPage: true,
-            workflowParentPath: '/planner/paternity-leave/start'
-          }
         },
         'shared-parental-leave': {
           url: '/planner/shared-parental-leave',
@@ -213,10 +208,10 @@ class Paths {
           workflowParentPath: (data, isForValidator) => {
             if (isForValidator) {
               // Prevent circular reference when validating page history.
-              return '/planner/paternity-leave/end'
+              return '/planner/paternity-leave/start'
             }
             const splBlockPlanningOrder = dataUtils.splBlockPlanningOrder(data)
-            return splBlockPlanningOrder.length > 0 ? '/planner/shared-parental-leave/end' : '/planner/paternity-leave/end'
+            return splBlockPlanningOrder.length > 0 ? '/planner/shared-parental-leave/end' : '/planner/paternity-leave/start'
           },
           start: {
             url: '/planner/shared-parental-leave/start',

--- a/app/router.js
+++ b/app/router.js
@@ -248,15 +248,22 @@ router.route(paths.getPath('planner.paternity-leave.start'))
     res.render('accessible-planner/paternity-leave-start')
   })
   .post(function (req, res) {
-    res.redirect(paths.getPath('planner.paternity-leave.end'))
-  })
-
-router.route(paths.getPath('planner.paternity-leave.end'))
-  .get(function (req, res) {
-    clearLaterLeaveBlockAnswers(req, 'secondary.initial.end')
-    res.render('accessible-planner/paternity-leave-end')
-  })
-  .post(function (req, res) {
+    const startData = delve(req.session.data, 'leave-blocks.secondary.initial.start')
+    const updatedData = {
+        initial: [
+          {
+            start: startData[0],
+            end: parseInt(startData[0]) + 1,
+            leave: 'paternity'
+          },
+          {
+            start: startData[1],
+            end: parseInt(startData[1]) + 1,
+            leave: 'paternity'
+          }
+        ]
+      }
+    dset(req.session.data, 'leave-blocks.secondary.initial', updatedData.initial)
     res.redirect(paths.getPath('planner.shared-parental-leave'))
   })
 

--- a/app/views/accessible-planner/answers-so-far/macro.njk
+++ b/app/views/accessible-planner/answers-so-far/macro.njk
@@ -21,6 +21,11 @@
   <h2 class="govuk-heading-m">
     Your answers so far
   </h2>
+<p>
+  Leave{{ leaveBlocks["secondary"]["initial"][0].start }}
+    Leave{{ leaveBlocks["secondary"]["initial"][1].start }}
+</p>
+
   {{ govukSummaryList({
     rows: [
       {
@@ -76,10 +81,10 @@
       },
       {
         key: {
-          text: "Paternity Leave start"
+          text: "Paternity Leave start (week 1)"
         },
         value: {
-          text: date(data, leaveBlocks["secondary"]["initial"]["start"])
+          text: date(data, leaveBlocks["secondary"]["initial"][0]["start"])
         },
         actions: {
           items: [
@@ -93,17 +98,17 @@
       },
       {
         key: {
-          text: "Paternity Leave end"
+          text: "Paternity Leave start (week 2)"
         },
         value: {
-          text: dateEnd(data, leaveBlocks["secondary"]["initial"]["end"])
+          text: date(data, leaveBlocks["secondary"]["initial"][1]["start"])
         },
         actions: {
           items: [
             {
-              href: "/planner/paternity-leave/end",
+              href: "/planner/paternity-leave/start",
               text: "Change",
-              visuallyHiddenText: "Paternity Leave end"
+              visuallyHiddenText: "Paternity Leave start"
             }
           ]
         }

--- a/app/views/accessible-planner/paternity-leave-end.njk
+++ b/app/views/accessible-planner/paternity-leave-end.njk
@@ -25,7 +25,7 @@
 {% set isOverseasAdoption = (data | isOverseasAdoption) %}
 {% set zeroWeek = (data | zeroWeek) %}
 {% set firstWeekOfLeave = (data["leave-blocks"]["secondary"]["initial"]["start"] | int) %}
-{% set options = range(firstWeekOfLeave, firstWeekOfLeave + 2 if firstWeekOfLeave < 7 else 8) %}
+{% set options = range(firstWeekOfLeave, firstWeekOfLeave + 2 if firstWeekOfLeave < 51 else 52) %}
 
 {% macro optionText(weekNumber) %}
   {% set totalWeeks = weekNumber - firstWeekOfLeave + 1 %}

--- a/app/views/accessible-planner/paternity-leave-start.njk
+++ b/app/views/accessible-planner/paternity-leave-start.njk
@@ -28,7 +28,7 @@
 {% set birthOrPlacement= (data | birthOrPlacement) %}
 {% set primaryLeaveEnd = data["leave-blocks"]["primary"]["initial"]["end"] %}
 
-{% set options = range(0, 8) %}
+{% set options = range(0, 52) %}
 
 {% macro optionText(weekNumber) %}
   {% if (weekNumber === 0) %}

--- a/app/views/accessible-planner/paternity-leave-start.njk
+++ b/app/views/accessible-planner/paternity-leave-start.njk
@@ -26,9 +26,9 @@
 {% set zeroWeek = (data | zeroWeek) %}
 {% set isAdoption = (data | isAdoption) %}
 {% set birthOrPlacement= (data | birthOrPlacement) %}
-{% set primaryLeaveEnd = data["leave-blocks"]["primary"]["initial"]["end"] %}
+{% set primaryLeaveEnd = data["leave-blocks"]["primary"]["initial"]["end"] | float %}
 
-{% set options = range(0, 52) %}
+{% set options = range(primaryLeaveEnd + 1) %}
 
 {% macro optionText(weekNumber) %}
   {% if (weekNumber === 0) %}
@@ -49,7 +49,17 @@
               id: "primary-leave-start",
               name: "leave-blocks[secondary][initial][start]",
               label: {
-                text: "When will Paternity Leave start?",
+                text: "When will the first week of Paternity Leave start?",
+                classes: "govuk-label--l",
+                isPageHeading: true
+              },
+              items: options | mapValuesToSelectOptions(optionText)
+            }) }}
+            {{ govukSelect({
+              id: "primary-leave-start",
+              name: "leave-blocks[secondary][initial][start]",
+              label: {
+                text: "When will the second week of Paternity Leave start?",
                 classes: "govuk-label--l",
                 isPageHeading: true
               },

--- a/app/views/accessible-planner/paternity-leave.njk
+++ b/app/views/accessible-planner/paternity-leave.njk
@@ -42,8 +42,7 @@
         {% call appendHiddenFields(data) %}
           {% set hint %}
             <p class="govuk-hint">
-              A partner can take up to 2 weeks of Paternity Leave in the first 8 weeks after {{ birthOrPlacement }}.
-              Weeks must be taken together, without breaks.
+              A partner can take up to 2 weeks of Paternity Leave in the first year after {{ birthOrPlacement }}.
             </p>
             {% if (remainingLeaveAllowance > 0) %}
               <p class="govuk-hint">

--- a/app/views/components/paternity-leave-block-summary.njk
+++ b/app/views/components/paternity-leave-block-summary.njk
@@ -25,7 +25,7 @@
           text: "Length"
         },
         value: {
-          text: options.block.length | weeks
+          text: options.block | paternalBlockLength | weeks
         }
       },
       {

--- a/app/views/components/paternity-leave-block-summary.njk
+++ b/app/views/components/paternity-leave-block-summary.njk
@@ -1,0 +1,42 @@
+{% from "summary-list/macro.njk" import govukSummaryList %}
+
+{% macro paternityLeaveBlockSummary(options) %}
+  {{ govukSummaryList({
+    classes: "summary-block-print-margin",
+    rows: [
+      {
+        key: {
+          text: options.name + " starts (week 1)"
+        },
+        value: {
+          text: "week starting " + options.data | startDay | startOfWeek | offsetWeeks(options.block[0].start) | formatForDisplay
+        }
+      },
+      {
+        key: {
+          text: options.name + " starts (week 2)"
+        },
+        value: {
+          text: "week starting " + options.data | startDay | startOfWeek | offsetWeeks(options.block[1].start) | formatForDisplay
+        }
+      } if options.block.length > 1 else "",
+      {
+        key: {
+          text: "Length"
+        },
+        value: {
+          text: options.block.length | weeks
+        }
+      },
+      {
+        key: {
+          text: "Notify employers"
+        },
+        value: {
+          html: "by " + (options.notify.date | formatForDisplay) + ("*" if options.notify.asterisk) + "<br>" +
+            "(" + options.notify.explanation + ")"
+        }
+      }
+    ]
+  }) }}
+{% endmacro %}

--- a/app/views/tabs/leave-summary.njk
+++ b/app/views/tabs/leave-summary.njk
@@ -1,6 +1,7 @@
 {% from "summary-list/macro.njk" import govukSummaryList %}
 {% from "inset-text/macro.njk" import govukInsetText %}
 {% from "../components/leave-block-summary.njk" import leaveBlockSummary %}
+{% from "../components/paternity-leave-block-summary.njk" import paternityLeaveBlockSummary %}
 
 {% set primaryLeaveType = (data | primaryLeaveType) %}
 
@@ -77,7 +78,7 @@
           <p>Paternity Leave can start at any point in the first year after the birth of the child.</p>
         {% endif %}
 
-        {{ leaveBlockSummary({
+        {{ paternityLeaveBlockSummary({
           name: "Paternity Leave",
           block: leaveBlocks.secondary.initial,
           data: data,

--- a/app/views/tabs/leave-summary.njk
+++ b/app/views/tabs/leave-summary.njk
@@ -72,9 +72,9 @@
         </h3>
 
         {% if data | isAdoption %}
-          <p>Paternity Leave can start the day your child is placed with you, or within 8 weeks after.</p>
+          <p>Paternity Leave can start at any point in the first year after the adoption of the child.</p>
         {% else %}
-          <p>Paternity Leave can start once the child is born, or within 8 weeks of the child’s birth.</p>
+          <p>Paternity Leave can start at any point in the first year after the birth of the child.</p>
         {% endif %}
 
         {{ leaveBlockSummary({


### PR DESCRIPTION
- Allow Paternity Leave to be taken at any time, but restricted to the Maternity Leave period
- Allow Paternity Leave to be taken in two separate blocks of one week
- Update various text