### PR TITLE
SPL-495 - update govuk-frontend to 5.1.0

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function (grunt) {
         {
           expand: true,
           cwd: 'node_modules/govuk-frontend/dist/govuk/assets/',
-          src: ['**/*' ],
+          src: ['**/*'],
           dest: 'public/assets/'
         }
       ]

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
           expand: true,
           cwd: 'common/assets/',
           src: ['**/*', '!sass/**', '!javascripts/**'],
-          dest: 'public/'
+          dest: 'public/assets/'
         }
       ]
     },
@@ -48,7 +48,17 @@ module.exports = function (grunt) {
           expand: true,
           cwd: 'app/assets/',
           src: ['**/*', '!sass/**', '!javascripts/**'],
-          dest: 'public/'
+          dest: 'public/assets/'
+        }
+      ]
+    },
+    govukFrontendAssets: {
+      files: [
+        {
+          expand: true,
+          cwd: 'node_modules/govuk-frontend/dist/govuk/assets/',
+          src: ['**/*' ],
+          dest: 'public/assets/'
         }
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "express": "^4.21.1",
         "express-session": "^1.18.1",
         "file-url": "^3.0.0",
-        "govuk-frontend": "^5.7.1",
+        "govuk-frontend": "^5.1.0",
         "is-iexplorer": "^1.0.0",
         "jsdom": "^25.0.1",
         "lodash": "^4.17.15",
@@ -8861,9 +8861,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
-      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.1.0.tgz",
+      "integrity": "sha512-Dc3J+uOI4i2VR3BVyfxbf6qVjTT4n4bBqbD0/Io6feP8pt/4IfKdP1vWimZf+BwMKKMXacw10hmdy5UcD6Cr8w==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.21.1",
     "express-session": "^1.18.1",
     "file-url": "^3.0.0",
-    "govuk-frontend": "^5.7.1",
+    "govuk-frontend": "^5.1.0",
     "is-iexplorer": "^1.0.0",
     "jsdom": "^25.0.1",
     "lodash": "^4.17.15",

--- a/test/features/cookies.spec.js
+++ b/test/features/cookies.spec.js
@@ -15,8 +15,12 @@ test.describe('cookies', () => {
     await checkUrl(page, '/cookies')
   })
 
-  test('should display analytical cookies in table', async ({ setUpCookiesPage: page }) => {
-    const analyticalCookiesTable = page.locator('#main-content > div > div > table:nth-child(11)')
+  test('should display analytical cookies in table', async ({
+    setUpCookiesPage: page
+  }) => {
+    const analyticalCookiesTable = page.locator(
+      '#main-content > div > div > table:nth-child(11)'
+    )
     await expect(analyticalCookiesTable).toContainText('_ga')
     await expect(analyticalCookiesTable).toContainText('_ga_NJ98WRPX')
     await expect(analyticalCookiesTable).toContainText('_gat')
@@ -28,25 +32,31 @@ test.describe('cookies', () => {
   })
 
   test('should enable cookies when accepted', async ({ page }) => {
-    await page.check("input[value='on']")
+    await page.check("input[value='on']", { force: true })
 
     await expect(page.locator("input[value='on']")).toBeChecked()
 
     await page.click('button:text("Save")')
 
     const cookies = await page.context().cookies()
-    const analyticalCookies = cookies.find(cookie => cookie.name === 'cm-user-preferences')
+    const analyticalCookies = cookies.find(
+      (cookie) => cookie.name === 'cm-user-preferences'
+    )
     expect(analyticalCookies.value).toBe('%7B%22analytics%22%3A%22on%22%7D')
   })
 
-  test('should display success message after accepting cookies', async ({ page }) => {
-    await page.check("input[value='on']")
+  test('should display success message after accepting cookies', async ({
+    page
+  }) => {
+    await page.check("input[value='on']", { force: true })
 
     await expect(page.locator("input[value='on']")).toBeChecked()
 
     await page.click('button:text("Save")')
 
     const successMessage = page.locator('#cookie-preference-success > div')
-    await expect(successMessage).toContainText('Government services may set additional cookies and, if so, will have their own cookie policy and banner.')
+    await expect(successMessage).toContainText(
+      'Government services may set additional cookies and, if so, will have their own cookie policy and banner.'
+    )
   })
 })

--- a/test/features/fixtures/adoption/planner/uk-adoption-all-eligible.js
+++ b/test/features/fixtures/adoption/planner/uk-adoption-all-eligible.js
@@ -22,7 +22,7 @@ const test = base.extend({
       false,
       async (page) => {
         // Type of adoption (UK Adoption specific to this route)
-        await page.getByLabel('UK Adoption').click()
+        await page.getByLabel('UK Adoption').click({ force: true })
         await page.click('button:text("Continue")')
       }
     )

--- a/test/features/fixtures/adoption/planner/uk-adoption-mother-eligible-partner-not-eligible.js
+++ b/test/features/fixtures/adoption/planner/uk-adoption-mother-eligible-partner-not-eligible.js
@@ -26,7 +26,7 @@ const test = base.extend({
       additionalLeaveQuestions,
       async (page) => {
         // Type of adoption (UK Adoption specific to this route)
-        await page.getByLabel('UK Adoption').click()
+        await page.getByLabel('UK Adoption').click({ force: true })
         await page.click('button:text("Continue")')
       }
     )

--- a/test/features/fixtures/adoption/select-adoption.js
+++ b/test/features/fixtures/adoption/select-adoption.js
@@ -3,8 +3,8 @@ const { test: base } = require('@playwright/test')
 const test = base.extend({
   setupAdoptionPage: async ({ page, baseURL }, use) => {
     await page.goto(`${baseURL}`)
-    await page.check("input[value='adoption']")
-    await page.click('button:text("Continue")')
+    await page.check("input[value='adoption']", { force: true })
+    await page.click('button:text("Continue")', { force: true })
     await use(page)
   }
 })

--- a/test/features/fixtures/adoption/select-partners-leave-and-pay.js
+++ b/test/features/fixtures/adoption/select-partners-leave-and-pay.js
@@ -3,8 +3,18 @@ const SelectUKAdoption = require('./select-uk-adoption-and-SPL-and-SSPP')
 
 const test = SelectUKAdoption.extend({
   setupPartnersLeaveAndPay: async ({ setupUKAdoptionPage: page }, use) => {
-    await page.getByRole('group', { name: 'Is the partner eligible for Shared Parental Leave?' }).getByLabel('Yes').click()
-    await page.getByRole('group', { name: 'Is the partner eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click()
+    await page
+      .getByRole('group', {
+        name: 'Is the partner eligible for Shared Parental Leave?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
+    await page
+      .getByRole('group', {
+        name: 'Is the partner eligible for Statutory Shared Parental Pay?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
     await page.click('button:text("Continue")')
     await use(page)
   }

--- a/test/features/fixtures/adoption/select-uk-adoption-and-SPL-and-SSPP.js
+++ b/test/features/fixtures/adoption/select-uk-adoption-and-SPL-and-SSPP.js
@@ -3,10 +3,20 @@ const SelectAdoption = require('./select-adoption')
 
 const test = SelectAdoption.extend({
   setupUKAdoptionPage: async ({ setupAdoptionPage: page }, use) => {
-    await page.check("input[value='uk']")
+    await page.check("input[value='uk']", { force: true })
     await page.click('button:text("Continue")')
-    await page.getByRole('group', { name: 'Is the primary adopter eligible for Shared Parental Leave?' }).getByLabel('Yes').click()
-    await page.getByRole('group', { name: 'Is the primary adopter eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click()
+    await page
+      .getByRole('group', {
+        name: 'Is the primary adopter eligible for Shared Parental Leave?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
+    await page
+      .getByRole('group', {
+        name: 'Is the primary adopter eligible for Statutory Shared Parental Pay?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
     await page.click('button:text("Continue")')
     await use(page)
   }

--- a/test/features/fixtures/birth/leaveSummary/mother-eligible-partner-eligible.js
+++ b/test/features/fixtures/birth/leaveSummary/mother-eligible-partner-eligible.js
@@ -2,21 +2,43 @@ const { test: base } = require('@playwright/test')
 
 // Utility function to select a leave week for a given parent
 async function selectLeave (page, parent, week) {
-  await page.click(`td[data-row="${week}"][data-column="${parent === 'mother' ? 0 : 2}"]`)
+  await page.click(
+    `td[data-row="${week}"][data-column="${parent === 'mother' ? 0 : 2}"]`
+  )
 }
 
 const test = base.extend({
   setupLeavePage: async ({ page, baseURL }, use) => {
     await page.goto(`${baseURL}`)
-    await page.check("input[value='birth']")
+    await page.check("input[value='birth']", { force: true })
     await page.click('button:text("Continue")')
 
-    await page.getByRole('group', { name: 'Is the mother eligible for Shared Parental Leave?' }).getByLabel('Yes').click()
-    await page.getByRole('group', { name: 'Is the mother eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click()
+    await page
+      .getByRole('group', {
+        name: 'Is the mother eligible for Shared Parental Leave?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
+    await page
+      .getByRole('group', {
+        name: 'Is the mother eligible for Statutory Shared Parental Pay?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
     await page.click('button:text("Continue")')
 
-    await page.getByRole('group', { name: 'Is the partner eligible for Shared Parental Leave?' }).getByLabel('Yes').click()
-    await page.getByRole('group', { name: 'Is the partner eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click()
+    await page
+      .getByRole('group', {
+        name: 'Is the partner eligible for Shared Parental Leave?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
+    await page
+      .getByRole('group', {
+        name: 'Is the partner eligible for Statutory Shared Parental Pay?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
     await page.click('button:text("Continue")')
 
     // -------------------------------------------------------------------
@@ -37,7 +59,9 @@ const test = base.extend({
 
     await page.click('button:text("Continue")')
 
-    await page.getByRole('link', { name: 'Skip this question' }).click()
+    await page
+      .getByRole('link', { name: 'Skip this question' })
+      .click({ force: true })
 
     // -------------------------------------------------------------------
 

--- a/test/features/fixtures/birth/planner/none-eligible.js
+++ b/test/features/fixtures/birth/planner/none-eligible.js
@@ -4,7 +4,7 @@ const test = base.extend({
   setupPlannerPageNoneEligible: async ({ page, baseURL }, use) => {
     // Nature of parenthood (birth/adoption/surrogacy)
     await page.goto(`${baseURL}`)
-    await page.check("input[value='birth']")
+    await page.check("input[value='birth']", { force: true })
     await page.click('button:text("Continue")')
 
     // eligibility/mother/shared-parental-leave-and-pay
@@ -13,13 +13,13 @@ const test = base.extend({
         name: 'Is the mother eligible for Shared Parental Leave?'
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page
       .getByRole('group', {
         name: 'Is the mother eligible for Statutory Shared Parental Pay?'
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page.click('button:text("Continue")')
 
     // eligibility/mother/initial-leave-and-pay
@@ -28,13 +28,13 @@ const test = base.extend({
         name: 'Is the mother eligible for Maternity Leave?'
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page
       .getByRole('group', {
         name: 'Is the mother eligible for Statutory Maternity Pay?'
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page.click('button:text("Continue")')
 
     // eligibility/mother/maternity-allowance
@@ -43,7 +43,7 @@ const test = base.extend({
         name: 'Is the mother eligible for Maternity Allowance?'
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page.click('button:text("Continue")')
 
     await use(page)

--- a/test/features/fixtures/birth/select-birth.js
+++ b/test/features/fixtures/birth/select-birth.js
@@ -3,7 +3,7 @@ const { test: base } = require('@playwright/test')
 const test = base.extend({
   setupBirthPage: async ({ page, baseURL }, use) => {
     await page.goto(`${baseURL}`)
-    await page.check("input[value='birth']")
+    await page.check("input[value='birth']", { force: true })
     await page.click('button:text("Continue")')
     await use(page)
   }

--- a/test/features/fixtures/birth/select-mothers-leave-and-pay.js
+++ b/test/features/fixtures/birth/select-mothers-leave-and-pay.js
@@ -2,8 +2,8 @@ const SelectBirth = require('./select-birth')
 
 const test = SelectBirth.extend({
   setupMothersLeaveAndPay: async ({ setupBirthPage: page }, use) => {
-    await page.getByRole('group', { name: 'Is the mother eligible for Shared Parental Leave?' }).getByLabel('Yes').click()
-    await page.getByRole('group', { name: 'Is the mother eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click()
+    await page.getByRole('group', { name: 'Is the mother eligible for Shared Parental Leave?' }).getByLabel('Yes').click({ force: true })
+    await page.getByRole('group', { name: 'Is the mother eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click({ force: true })
     await page.click('button:text("Continue")')
     await use(page)
   }

--- a/test/features/fixtures/birth/select-partners-leave-and-pay.js
+++ b/test/features/fixtures/birth/select-partners-leave-and-pay.js
@@ -2,8 +2,8 @@ const SelectMothersLeaveAndPay = require('./select-mothers-leave-and-pay')
 
 const test = SelectMothersLeaveAndPay.extend({
   setupPartnersLeaveAndPay: async ({ setupMothersLeaveAndPay: page }, use) => {
-    await page.getByRole('group', { name: 'Is the partner eligible for Shared Parental Leave?' }).getByLabel('Yes').click()
-    await page.getByRole('group', { name: 'Is the partner eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click()
+    await page.getByRole('group', { name: 'Is the partner eligible for Shared Parental Leave?' }).getByLabel('Yes').click({ force: true })
+    await page.getByRole('group', { name: 'Is the partner eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click({ force: true })
     await page.click('button:text("Continue")')
     await use(page)
   }

--- a/test/features/fixtures/surrogacy/select-parental-order-leave-and-pay.js
+++ b/test/features/fixtures/surrogacy/select-parental-order-leave-and-pay.js
@@ -2,8 +2,18 @@ const SelectSurrogacy = require('./select-surrogacy')
 
 const test = SelectSurrogacy.extend({
   setupParentalOrder: async ({ setupSurrogacyPage: page }, use) => {
-    await page.getByRole('group', { name: 'Is the parental order parent eligible for Shared Parental Leave?' }).getByLabel('Yes').click()
-    await page.getByRole('group', { name: 'Is the parental order parent eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click()
+    await page
+      .getByRole('group', {
+        name: 'Is the parental order parent eligible for Shared Parental Leave?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
+    await page
+      .getByRole('group', {
+        name: 'Is the parental order parent eligible for Statutory Shared Parental Pay?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
     await page.click('button:text("Continue")')
     await use(page)
   }

--- a/test/features/fixtures/surrogacy/select-partners-leave-and-pay.js
+++ b/test/features/fixtures/surrogacy/select-partners-leave-and-pay.js
@@ -2,8 +2,18 @@ const SelectParentOrder = require('./select-parental-order-leave-and-pay')
 
 const test = SelectParentOrder.extend({
   setupPartnersLeaveAndPay: async ({ setupParentalOrder: page }, use) => {
-    await page.getByRole('group', { name: 'Is the partner eligible for Shared Parental Leave?' }).getByLabel('Yes').click()
-    await page.getByRole('group', { name: 'Is the partner eligible for Statutory Shared Parental Pay?' }).getByLabel('Yes').click()
+    await page
+      .getByRole('group', {
+        name: 'Is the partner eligible for Shared Parental Leave?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
+    await page
+      .getByRole('group', {
+        name: 'Is the partner eligible for Statutory Shared Parental Pay?'
+      })
+      .getByLabel('Yes')
+      .click({ force: true })
     await page.click('button:text("Continue")')
     await use(page)
   }

--- a/test/features/fixtures/surrogacy/select-surrogacy.js
+++ b/test/features/fixtures/surrogacy/select-surrogacy.js
@@ -3,7 +3,7 @@ const { test: base } = require('@playwright/test')
 const test = base.extend({
   setupSurrogacyPage: async ({ page, baseURL }, use) => {
     await page.goto(`${baseURL}`)
-    await page.check("input[value='surrogacy']")
+    await page.check("input[value='surrogacy']", { force: true })
     await page.click('button:text("Continue")')
     await use(page)
   }

--- a/test/features/google-analytics.spec.js
+++ b/test/features/google-analytics.spec.js
@@ -29,7 +29,7 @@ test.describe('check head elements', () => {
     await page.reload()
 
     await page.click('body > footer > div > div > div.govuk-footer__meta-item.govuk-footer__meta-item--grow > ul > li:nth-child(1) > a')
-    await page.check("input[value='off']")
+    await page.check("input[value='off']", { force: true })
     await expect(page.locator("input[value='off']")).toBeChecked()
     await page.click('button:text("Save")')
     await page.waitForTimeout(2000)

--- a/test/features/helpers/plannerSetup.js
+++ b/test/features/helpers/plannerSetup.js
@@ -9,7 +9,9 @@ async function commonSetup (
 ) {
   // Nature of parenthood (birth/adoption/surrogacy)
   await page.goto(`${baseURL}`)
-  await page.check(`input[value='${natureOfParenthoodValue}']`)
+  await page.check(`input[value='${natureOfParenthoodValue}']`, {
+    force: true
+  })
   await page.click('button:text("Continue")')
 
   // Call the additional setup steps specific to each route
@@ -24,13 +26,13 @@ async function commonSetup (
       name: `Is the ${primaryParent.name} eligible for Shared Parental Leave?`
     })
     .getByLabel(primaryParent.splEligible)
-    .click()
+    .click({ force: true })
   await page
     .getByRole('group', {
       name: `Is the ${primaryParent.name} eligible for Statutory Shared Parental Pay?`
     })
     .getByLabel(primaryParent.splPayEligible)
-    .click()
+    .click({ force: true })
   await page.click('button:text("Continue")')
 
   if (
@@ -43,13 +45,13 @@ async function commonSetup (
         name: `Is the ${primaryParent.name} eligible for Maternity Leave?`
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page
       .getByRole('group', {
         name: `Is the ${primaryParent.name} eligible for Statutory Maternity Pay?`
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page.click('button:text("Continue")')
 
     // eligibility/mother/maternity-allowance
@@ -58,7 +60,7 @@ async function commonSetup (
         name: `Is the ${primaryParent.name} eligible for Maternity Allowance?`
       })
       .getByLabel(primaryParent.materinitAllowanceEligible)
-      .click()
+      .click({ force: true })
     await page.click('button:text("Continue")')
   }
 
@@ -69,13 +71,13 @@ async function commonSetup (
       name: `Is the ${secondaryParent.name} eligible for Shared Parental Leave?`
     })
     .getByLabel(secondaryParent.splEligible)
-    .click()
+    .click({ force: true })
   await page
     .getByRole('group', {
       name: `Is the ${secondaryParent.name} eligible for Statutory Shared Parental Pay?`
     })
     .getByLabel(secondaryParent.splPayEligible)
-    .click()
+    .click({ force: true })
   await page.click('button:text("Continue")')
 
   if (
@@ -88,13 +90,13 @@ async function commonSetup (
         name: `Is the ${secondaryParent.name} eligible for Paternity Leave?`
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page
       .getByRole('group', {
         name: `Is the ${secondaryParent.name} eligible for Statutory Paternity Pay?`
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page.click('button:text("Continue")')
   }
 

--- a/test/features/nature-of-parenthood.spec.js
+++ b/test/features/nature-of-parenthood.spec.js
@@ -13,9 +13,15 @@ test.describe('nature-of-parenthood', () => {
   })
 
   test('should allow me to check birth and continue', async ({ page }) => {
-    await page.check("input[value='birth']") // <- Click on birth
+    await page.check(
+      '#main-content > div > div > form > div > fieldset > div.govuk-radios.govuk-radios > div:nth-child(1) > label'
+    ) // <- Click on birth
 
-    await expect(page.locator("input[value='birth']")).toBeChecked()
+    await expect(
+      page.locator(
+        '#main-content > div > div > form > div > fieldset > div.govuk-radios.govuk-radios > div:nth-child(1) > label'
+      )
+    ).toBeChecked()
 
     await page.click('button:text("Continue")') // <- Click on continue button
 
@@ -25,9 +31,15 @@ test.describe('nature-of-parenthood', () => {
   })
 
   test('should allow me to check adoption and continue', async ({ page }) => {
-    await page.check("input[value='adoption']") // <- Click on adoption
+    await page.check(
+      '#main-content > div > div > form > div > fieldset > div.govuk-radios.govuk-radios > div:nth-child(2) > label'
+    ) // <- Click on adoption
 
-    await expect(page.locator("input[value='adoption']")).toBeChecked()
+    await expect(
+      page.locator(
+        '#main-content > div > div > form > div > fieldset > div.govuk-radios.govuk-radios > div:nth-child(2) > label'
+      )
+    ).toBeChecked()
 
     await page.click('button:text("Continue")') // <- Click on continue button
 
@@ -39,9 +51,15 @@ test.describe('nature-of-parenthood', () => {
   })
 
   test('should allow me to check surrogacy and continue', async ({ page }) => {
-    await page.check("input[value='surrogacy']") // <- Click on surrogacy
+    await page.check(
+      '#main-content > div > div > form > div > fieldset > div.govuk-radios.govuk-radios > div:nth-child(3) > label'
+    ) // <- Click on surrogacy
 
-    await expect(page.locator("input[value='surrogacy']")).toBeChecked()
+    await expect(
+      page.locator(
+        '#main-content > div > div > form > div > fieldset > div.govuk-radios.govuk-radios > div:nth-child(3) > label'
+      )
+    ).toBeChecked()
 
     await page.click('button:text("Continue")') // <- Click on continue button
 

--- a/test/features/scenarios/adoption/primary-leave-and-pay.spec.js
+++ b/test/features/scenarios/adoption/primary-leave-and-pay.spec.js
@@ -21,17 +21,17 @@ test.describe('when "adoption" is selected on "nature-of-parenthood"', () => {
     test('radio buttons should be clickable', async ({
       setupAdoptionPage: page
     }) => {
-      await page.check("input[value='uk']")
+      await page.check("input[value='uk']", { force: true })
       await expect(page.locator("input[value='uk']")).toBeChecked()
 
-      await page.check("input[value='overseas']")
+      await page.check("input[value='overseas']", { force: true })
       await expect(page.locator("input[value='overseas']")).toBeChecked()
     })
 
     test('continue button should be clickable', async ({
       setupAdoptionPage: page
     }) => {
-      await page.check("input[value='uk']")
+      await page.check("input[value='uk']", { force: true })
 
       await page.click('button:text("Continue")') // <- Click on continue button
 
@@ -58,7 +58,7 @@ test.describe('when "adoption" is selected on "nature-of-parenthood"', () => {
 
   test.describe('and "UK Adoption" is selected', () => {
     test.beforeEach(async ({ setupAdoptionPage: page }) => {
-      await page.check("input[value='uk']")
+      await page.check("input[value='uk']", { force: true })
       await page.click('button:text("Continue")')
     })
 
@@ -76,13 +76,13 @@ test.describe('when "adoption" is selected on "nature-of-parenthood"', () => {
           name: 'Is the primary adopter eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the primary adopter eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -100,13 +100,13 @@ test.describe('when "adoption" is selected on "nature-of-parenthood"', () => {
           name: 'Is the primary adopter eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the primary adopter eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -124,13 +124,13 @@ test.describe('when "adoption" is selected on "nature-of-parenthood"', () => {
           name: 'Is the primary adopter eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the primary adopter eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -148,13 +148,13 @@ test.describe('when "adoption" is selected on "nature-of-parenthood"', () => {
           name: 'Is the primary adopter eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the primary adopter eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(

--- a/test/features/scenarios/adoption/secondary-leave-and-pay.spec.js
+++ b/test/features/scenarios/adoption/secondary-leave-and-pay.spec.js
@@ -24,7 +24,7 @@ test.describe('when "adoption" then "UK Adoption" is selected on "nature-of-pare
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await expect(
         page
           .getByRole('group', {
@@ -38,7 +38,7 @@ test.describe('when "adoption" then "UK Adoption" is selected on "nature-of-pare
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await expect(
         page
           .getByRole('group', {
@@ -56,13 +56,13 @@ test.describe('when "adoption" then "UK Adoption" is selected on "nature-of-pare
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
 
       await page.click('button:text("Continue")') // <- Click on continue button
 
@@ -101,13 +101,13 @@ test.describe('when "adoption" then "UK Adoption" is selected on "nature-of-pare
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -125,13 +125,13 @@ test.describe('when "adoption" then "UK Adoption" is selected on "nature-of-pare
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await page
@@ -139,13 +139,13 @@ test.describe('when "adoption" then "UK Adoption" is selected on "nature-of-pare
           name: 'Is the partner eligible for Paternity Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Paternity Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -163,13 +163,13 @@ test.describe('when "adoption" then "UK Adoption" is selected on "nature-of-pare
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await page
@@ -177,13 +177,13 @@ test.describe('when "adoption" then "UK Adoption" is selected on "nature-of-pare
           name: 'Is the partner eligible for Paternity Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Paternity Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(

--- a/test/features/scenarios/birth/primary-leave-and-pay.spec.js
+++ b/test/features/scenarios/birth/primary-leave-and-pay.spec.js
@@ -34,7 +34,7 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click() // <- Click on Yes
+        .click({ force: true }) // <- Click on Yes
       await expect(
         page
           .getByRole('group', {
@@ -48,7 +48,7 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click() // <- Click on No
+        .click({ force: true }) // <- Click on No
       await expect(
         page
           .getByRole('group', {
@@ -62,7 +62,7 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click() // <- Click on Yes
+        .click({ force: true }) // <- Click on Yes
       await expect(
         page
           .getByRole('group', {
@@ -76,7 +76,7 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click() // <- Click on No
+        .click({ force: true }) // <- Click on No
       await expect(
         page
           .getByRole('group', {
@@ -94,13 +94,13 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click() // <- Click on Yes
+        .click({ force: true }) // <- Click on Yes
       await page
         .getByRole('group', {
           name: 'Is the mother eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click() // <- Click on Yes
+        .click({ force: true }) // <- Click on Yes
 
       await page.click('button:text("Continue")') // <- Click on continue button
 
@@ -119,7 +119,7 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click() // <- Click on Yes
+        .click({ force: true }) // <- Click on Yes
 
       await page.click('button:text("Continue")') // <- Click on continue button
 
@@ -158,13 +158,13 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the mother eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
     })
 
@@ -176,13 +176,13 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Maternity Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the mother eligible for Statutory Maternity Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -198,13 +198,13 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Maternity Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the mother eligible for Statutory Maternity Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -222,13 +222,13 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the mother eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the mother eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
     })
 
@@ -240,13 +240,13 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -264,13 +264,13 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -288,13 +288,13 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -310,13 +310,13 @@ test.describe('when "birth" is selected on "nature-of-parenthood"', () => {
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(

--- a/test/features/scenarios/birth/secondary-leave-and-pay.spec.js
+++ b/test/features/scenarios/birth/secondary-leave-and-pay.spec.js
@@ -24,7 +24,7 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await expect(
         page
           .getByRole('group', {
@@ -38,7 +38,7 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await expect(
         page
           .getByRole('group', {
@@ -56,13 +56,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
 
       await page.click('button:text("Continue")') // <- Click on continue button
 
@@ -101,13 +101,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -125,13 +125,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await page
@@ -139,13 +139,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Paternity Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Paternity Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -163,13 +163,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await page
@@ -177,13 +177,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Paternity Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Paternity Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(

--- a/test/features/scenarios/surrogacy/primary-leave-and-pay.spec.js
+++ b/test/features/scenarios/surrogacy/primary-leave-and-pay.spec.js
@@ -29,7 +29,7 @@ test.describe('when "surrogacy" is selected on "nature-of-parenthood"', () => {
           name: 'Is the parental order parent eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await expect(
         page
           .getByRole('group', {
@@ -43,7 +43,7 @@ test.describe('when "surrogacy" is selected on "nature-of-parenthood"', () => {
           name: 'Is the parental order parent eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await expect(
         page
           .getByRole('group', {
@@ -61,13 +61,13 @@ test.describe('when "surrogacy" is selected on "nature-of-parenthood"', () => {
           name: 'Is the parental order parent eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the parental order parent eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -104,13 +104,13 @@ test.describe('when "surrogacy" is selected on "nature-of-parenthood"', () => {
         name: 'Is the parental order parent eligible for Shared Parental Leave?'
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page
       .getByRole('group', {
         name: 'Is the parental order parent eligible for Statutory Shared Parental Pay?'
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page.click('button:text("Continue")')
 
     await expect(
@@ -128,13 +128,13 @@ test.describe('when "surrogacy" is selected on "nature-of-parenthood"', () => {
         name: 'Is the parental order parent eligible for Shared Parental Leave?'
       })
       .getByLabel('Yes')
-      .click()
+      .click({ force: true })
     await page
       .getByRole('group', {
         name: 'Is the parental order parent eligible for Statutory Shared Parental Pay?'
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page.click('button:text("Continue")')
 
     await expect(
@@ -152,13 +152,13 @@ test.describe('when "surrogacy" is selected on "nature-of-parenthood"', () => {
         name: 'Is the parental order parent eligible for Shared Parental Leave?'
       })
       .getByLabel('No')
-      .click()
+      .click({ force: true })
     await page
       .getByRole('group', {
         name: 'Is the parental order parent eligible for Statutory Shared Parental Pay?'
       })
       .getByLabel('Yes')
-      .click()
+      .click({ force: true })
     await page.click('button:text("Continue")')
 
     await expect(

--- a/test/features/scenarios/surrogacy/secondary-leave-and-pay.spec.js
+++ b/test/features/scenarios/surrogacy/secondary-leave-and-pay.spec.js
@@ -24,7 +24,7 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await expect(
         page
           .getByRole('group', {
@@ -38,7 +38,7 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await expect(
         page
           .getByRole('group', {
@@ -56,13 +56,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
 
       await page.click('button:text("Continue")') // <- Click on continue button
 
@@ -101,13 +101,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -125,13 +125,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await page
@@ -139,13 +139,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Paternity Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Paternity Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(
@@ -163,13 +163,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Shared Parental Leave?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Shared Parental Pay?'
         })
         .getByLabel('No')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await page
@@ -177,13 +177,13 @@ test.describe('when "surrogacy" then "parental order parents leave and pay" is s
           name: 'Is the partner eligible for Paternity Leave?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page
         .getByRole('group', {
           name: 'Is the partner eligible for Statutory Paternity Pay?'
         })
         .getByLabel('Yes')
-        .click()
+        .click({ force: true })
       await page.click('button:text("Continue")')
 
       await expect(


### PR DESCRIPTION
Assets are handled differently in v5+ - gruntfile updated to copy over assets from the govuk frontend package to the public folder for serving.

## For Testing

To test, run the `compile` task to rebuild the public folder and start the server with `start` rather than `dev` (`dev` doesn't use the public folder and rebuilds assets on every save). Then check that there are no console errors in browser, and that the footer crest, favicon and fonts present/working as intended