### PR TITLE
SPL-508 - add hidden honeypot "url" field to feedback form

### DIFF
--- a/app/emailjs-mailer.js
+++ b/app/emailjs-mailer.js
@@ -52,6 +52,7 @@ const sendMail = async (experience, moreDetails, emailjsIds, options, reqHeaders
       eventResult: 'Failure',
       errorDetails: err.text
     })
+    throw new Error(`Failed to send email: ${err.text}`)
   }
 }
 

--- a/app/router.js
+++ b/app/router.js
@@ -29,6 +29,9 @@ const {
 const dataUtils = require('../common/lib/dataUtils')
 const ShareTokenEncoder = require('./lib/shareToken/shareTokenEncoder')
 const healthcheck = require('./lib/healthcheck')
+const logger = require('./logger')
+
+// EmailJS configuration
 const options = {
   publicKey: config.emailJSPublicKey,
   privateKey: config.emailJSPrivateKey
@@ -420,13 +423,30 @@ router
   })
   .post(function (req, res) {
     if (!validate.feedback(req)) {
+      logger.error({
+        message: `Feedback form validation failed: ${JSON.stringify(req.body)}`,
+        eventType: 'ValidationFailure',
+        eventResult: 'ValidationFailure',
+        EventSeverity: 'Medium'
+      })
       return res.redirect(req.path)
     }
     const experience = req.body.feedback
     const moreDetail = req.body['feedback-more-detail']
-    emailJSEmail(experience, moreDetail, emailjsIds, options, req.headers).then(() =>
-      res.redirect('/feedback/confirmation')
-    )
+
+    emailJSEmail(experience, moreDetail, emailjsIds, options, req.headers)
+      .then(() => {
+        res.redirect('/feedback/confirmation')
+      })
+      .catch((err) => {
+        logger.error({
+          message: `Error sending feedback email: ${err.message}`,
+          eventType: 'MailEvent',
+          eventResult: 'Failure',
+          errorDetails: err.message
+        })
+        res.redirect('/feedback/confirmation')
+      })
   })
 
 router.route(paths.getPath('cookies')).get(function (req, res) {

--- a/app/validate.js
+++ b/app/validate.js
@@ -135,6 +135,10 @@ function feedback (req) {
     valid = false
   }
 
+  if (req.session.data.url) {
+    valid = false
+  }
+
   const value = req.session.data['spam-filter'].toLowerCase()
   if (!value.length) {
     addError(req, 'spam-filter', 'Prove you are not a robot.', '#spam-filter')

--- a/app/views/feedback/feedback.njk
+++ b/app/views/feedback/feedback.njk
@@ -108,6 +108,19 @@
           } if errors["spam-filter"]
         }) }}
 
+        <!-- Honeypot Field -->
+        <div style="display: none;">
+          {{ govukInput({
+            id: "url",
+            name: "url",
+            value: "",
+            label: {
+              text: "url",
+              classes: "govuk-label--s"
+            }
+          }) }}
+        </div>
+
         {{ govukButton({
           text: "Send Feedback",
           preventDoubleClick: true

--- a/test/unit/app/emailjs-mailer.test.js
+++ b/test/unit/app/emailjs-mailer.test.js
@@ -105,17 +105,19 @@ describe('sendMail', function () {
     })
 
     it('should log error message when an exception occurs', async function () {
-      const error = { text: 'Unexpected error' }
-      emailjsSendStub.throws(error)
+      const error = { text: 'Error sending email' }
+      emailjsSendStub.rejects(error)
 
-      await sendMail(experience, moreDetails, emailjsIds, options)
-
-      expect(loggerErrorStub.calledOnce).to.equal(true)
-      const logArgs = loggerErrorStub.getCall(0).args[0]
-      expect(logArgs.message).to.equal('Error sending feedback email: Unexpected error')
-      expect(logArgs.eventType).to.equal('MailEvent')
-      expect(logArgs.eventResult).to.equal('Failure')
-      expect(logArgs.errorDetails).to.equal('Unexpected error')
+      try {
+        await sendMail(experience, moreDetails, emailjsIds, options, userAgent)
+      } catch (err) {
+        expect(loggerErrorStub.calledOnce).to.equal(true)
+        const logArgs = loggerErrorStub.getCall(0).args[0]
+        expect(logArgs.message).to.equal('Error sending feedback email: Error sending email')
+        expect(logArgs.eventType).to.equal('MailEvent')
+        expect(logArgs.eventResult).to.equal('Failure')
+        expect(logArgs.errorDetails).to.equal('Error sending email')
+      }
     })
   })
 })

--- a/test/unit/app/emailjs-mailer.test.js
+++ b/test/unit/app/emailjs-mailer.test.js
@@ -31,7 +31,10 @@ describe('sendMail', function () {
     const experience = 'Great service!'
     const moreDetails = 'No additional feedback'
     const plannerText = 'Planner'
-    const emailjsIds = { serviceID: 'test_service', templateID: 'test_template' }
+    const emailjsIds = {
+      serviceID: 'test_service',
+      templateID: 'test_template'
+    }
     const options = { publicKey: 'test_public', privateKey: 'test_private' }
     const userAgent = { 'user-agent': 'test-agent' }
 
@@ -64,7 +67,10 @@ describe('sendMail', function () {
     it('should handle undefined userAgent gracefully', async function () {
       const experience = 'Great service!'
       const moreDetails = 'No additional feedback'
-      const emailjsIds = { serviceID: 'test_service', templateID: 'test_template' }
+      const emailjsIds = {
+        serviceID: 'test_service',
+        templateID: 'test_template'
+      }
       const options = { publicKey: 'test_public', privateKey: 'test_private' }
       const userAgent = undefined
 
@@ -86,7 +92,10 @@ describe('sendMail', function () {
   describe('failed email sending', function () {
     const experience = 'Great service!'
     const moreDetails = 'No additional feedback'
-    const emailjsIds = { serviceID: 'test_service', templateID: 'test_template' }
+    const emailjsIds = {
+      serviceID: 'test_service',
+      templateID: 'test_template'
+    }
     const options = { publicKey: 'test_public', privateKey: 'test_private' }
     const userAgent = { 'user-agent': 'test-agent' }
 
@@ -98,7 +107,9 @@ describe('sendMail', function () {
 
       expect(loggerErrorStub.calledOnce).to.equal(true)
       const logArgs = loggerErrorStub.getCall(0).args[0]
-      expect(logArgs.message).to.equal('Failed to send email. Error: Error sending email')
+      expect(logArgs.message).to.equal(
+        'Failed to send email. Error: Error sending email'
+      )
       expect(logArgs.eventType).to.equal('MailEvent')
       expect(logArgs.eventResult).to.equal('Failure')
       expect(logArgs.errorDetails).to.equal('Error sending email')
@@ -113,10 +124,25 @@ describe('sendMail', function () {
       } catch (err) {
         expect(loggerErrorStub.calledOnce).to.equal(true)
         const logArgs = loggerErrorStub.getCall(0).args[0]
-        expect(logArgs.message).to.equal('Error sending feedback email: Error sending email')
+        expect(logArgs.message).to.equal(
+          'Error sending feedback email: Error sending email'
+        )
         expect(logArgs.eventType).to.equal('MailEvent')
         expect(logArgs.eventResult).to.equal('Failure')
         expect(logArgs.errorDetails).to.equal('Error sending email')
+      }
+    })
+
+    it('should throw an error when emailjs.send rejects', async function () {
+      const error = { text: 'Error sending email' }
+      emailjsSendStub.rejects(error)
+
+      try {
+        await sendMail(experience, moreDetails, emailjsIds, options, userAgent)
+      } catch (err) {
+        expect(err.message).to.equal(
+          'Failed to send email: Error sending email'
+        )
       }
     })
   })

--- a/test/unit/app/router.test.js
+++ b/test/unit/app/router.test.js
@@ -1,15 +1,70 @@
 const supertest = require('supertest')
-const { describe, it } = require('mocha')
+const { describe, it, beforeEach } = require('mocha')
+const proxyrequire = require('proxyquire')
+const sinon = require('sinon')
 
 const getApp = require('../../../server').getApp
 const paths = require('../../../app/paths')
 
-describe('GET /', () => {
-  it('returns 302 status and redirects to the first question page', (done) => {
-    supertest(getApp())
-      .get(paths.getPath('root'))
-      .expect(302)
-      .expect('Location', paths.getPath('natureOfParenthood'))
-      .end(done)
+describe('router', () => {
+  describe('GET /', () => {
+    it('returns 302 status and redirects to the first question page', (done) => {
+      supertest(getApp())
+        .get(paths.getPath('root'))
+        .expect(302)
+        .expect('Location', paths.getPath('natureOfParenthood'))
+        .end(done)
+    })
+  })
+
+  describe('feedback', () => {
+    describe('GET /feedback', () => {
+      it('/feedback should return 200 status', (done) => {
+        supertest(getApp())
+          .get(paths.getPath('feedback'))
+          .expect(200)
+          .end(done)
+      })
+    })
+
+    describe('POST /feedback', () => {
+      beforeEach(() => {
+        const emailjsSendStub = sinon
+          .stub()
+          .resolves({ status: 200, text: 'OK' })
+
+        proxyrequire('../../../app/emailjs-mailer', {
+          '@emailjs/nodejs': {
+            send: emailjsSendStub
+          }
+        })
+      })
+      it('/feedback should return 302 status', (done) => {
+        supertest(getApp())
+          .post(paths.getPath('feedback'))
+          .send({
+            feedback: 'Great service!',
+            'feedback-more-detail': 'No additional feedback',
+            userAgent: 'test-agent',
+            'spam-filter': 'yes'
+          })
+          .expect(302)
+          .end(done)
+      })
+
+      it('should be redirected back to /feedback if url honeypot field is entered', (done) => {
+        supertest(getApp())
+          .post(paths.getPath('feedback'))
+          .send({
+            url: 'www.test-bot.com',
+            feedback: 'Great service!',
+            'feedback-more-detail': 'No additional feedback',
+            userAgent: 'test-agent',
+            'spam-filter': 'yes'
+          })
+          .expect(302)
+          .end(done)
+      })
+    })
   })
 })

--- a/test/unit/app/validate.test.js
+++ b/test/unit/app/validate.test.js
@@ -1097,6 +1097,17 @@ describe('validate.js', () => {
       expect(error).to.have.property('href', '#spam-filter')
     })
 
+    it('should return false if url is provided in feedback', () => {
+      req.session.data = {
+        url: 'www.bot-test.com',
+        feedback: 'Great service!',
+        'spam-filter': 'yes'
+      }
+
+      const result = validate.feedback(req)
+      expect(result).to.equal(false)
+    })
+
     it('should return true if feedback is provided and spam-filter value is valid', () => {
       req.session.data = {
         feedback: 'Great service!',


### PR DESCRIPTION
Add hidden field "url" to the feedback form - honeypot field. In theory, a bot should fill in all fields it finds (regardless of css hiding that field) and a "url" field should be _enticing_ for a bot. 