### PR TITLE
SPL-506 - update govuk-frontend to 5.7.1

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -47,8 +47,7 @@
     </header>
   {{ govukHeader({
     serviceName: service_name,
-    serviceUrl: "https://www.gov.uk/plan-shared-parental-leave-pay",
-    useTudorCrown: true
+    serviceUrl: "https://www.gov.uk/plan-shared-parental-leave-pay"
   }) }}
 {% endblock %}
 

--- a/common/assets/sass/application.scss
+++ b/common/assets/sass/application.scss
@@ -1,4 +1,5 @@
 $govuk-global-styles: true;
+$govuk-new-typography-scale: true;
 @import "govuk-frontend/dist/govuk/all";
 
 @import "components/cookie-message";

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "express": "^4.21.1",
         "express-session": "^1.18.1",
         "file-url": "^3.0.0",
-        "govuk-frontend": "^5.1.0",
+        "govuk-frontend": "^5.3.0",
         "is-iexplorer": "^1.0.0",
         "jsdom": "^25.0.1",
         "lodash": "^4.17.15",
@@ -8861,10 +8861,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.1.0.tgz",
-      "integrity": "sha512-Dc3J+uOI4i2VR3BVyfxbf6qVjTT4n4bBqbD0/Io6feP8pt/4IfKdP1vWimZf+BwMKKMXacw10hmdy5UcD6Cr8w==",
-      "license": "MIT",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.0.tgz",
+      "integrity": "sha512-w6yaaDU3nqhVmWJFnOuJKRIUEB/2RrTFGzoA3z5n4cTG9h292EseT/q+JJA/LYTf5IYzeTIVAUbE5fFjUxefiQ==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "express": "^4.21.1",
         "express-session": "^1.18.1",
         "file-url": "^3.0.0",
-        "govuk-frontend": "^5.4.1",
+        "govuk-frontend": "^5.7.1",
         "is-iexplorer": "^1.0.0",
         "jsdom": "^25.0.1",
         "lodash": "^4.17.15",
@@ -8861,9 +8861,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.1.tgz",
-      "integrity": "sha512-Gmd8LV++TRh9OF6tA+9KQTpwvlsLcri7qRjViz9ji4YuwZvX+c9TD7tyE+dnJcqsQsJfhr9Fp38m3Hu3H7EIcQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
+      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "express": "^4.21.1",
         "express-session": "^1.18.1",
         "file-url": "^3.0.0",
-        "govuk-frontend": "^5.3.0",
+        "govuk-frontend": "^5.4.1",
         "is-iexplorer": "^1.0.0",
         "jsdom": "^25.0.1",
         "lodash": "^4.17.15",
@@ -8861,9 +8861,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.0.tgz",
-      "integrity": "sha512-w6yaaDU3nqhVmWJFnOuJKRIUEB/2RrTFGzoA3z5n4cTG9h292EseT/q+JJA/LYTf5IYzeTIVAUbE5fFjUxefiQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.1.tgz",
+      "integrity": "sha512-Gmd8LV++TRh9OF6tA+9KQTpwvlsLcri7qRjViz9ji4YuwZvX+c9TD7tyE+dnJcqsQsJfhr9Fp38m3Hu3H7EIcQ==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "express": "^4.21.1",
     "express-session": "^1.18.1",
     "file-url": "^3.0.0",
-    "govuk-frontend": "^5.4.1",
+    "govuk-frontend": "^5.7.1",
     "is-iexplorer": "^1.0.0",
     "jsdom": "^25.0.1",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "express": "^4.21.1",
     "express-session": "^1.18.1",
     "file-url": "^3.0.0",
-    "govuk-frontend": "^5.1.0",
+    "govuk-frontend": "^5.3.0",
     "is-iexplorer": "^1.0.0",
     "jsdom": "^25.0.1",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "express": "^4.21.1",
     "express-session": "^1.18.1",
     "file-url": "^3.0.0",
-    "govuk-frontend": "^5.3.0",
+    "govuk-frontend": "^5.4.1",
     "is-iexplorer": "^1.0.0",
     "jsdom": "^25.0.1",
     "lodash": "^4.17.15",


### PR DESCRIPTION
- remove useTudorCrown
- apply new responsive font size
- 5.7.0 includes updates to Royal Arms logo

Notable differences between these updates and live - responsive font size and logos.